### PR TITLE
Yield `LEVEL_LOCKED` error when lock is held

### DIFF
--- a/README.md
+++ b/README.md
@@ -194,7 +194,7 @@ Read-only getter that returns a string reflecting the current state of the datab
 
 ### `db.open([options][, callback])`
 
-Open the database. The `callback` function will be called with no arguments when successfully opened, or with a single error argument if opening failed. If no callback is provided, a promise is returned. Options passed to `open()` take precedence over options passed to the database constructor.
+Open the database. The `callback` function will be called with no arguments when successfully opened, or with a single error argument if opening failed. The database has an exclusive lock (on disk): if another process or instance has already opened the underlying LevelDB store at the given `location` then opening will fail with error code [`LEVEL_LOCKED`](https://github.com/Level/abstract-level#errors). If no callback is provided, a promise is returned. Options passed to `open()` take precedence over options passed to the database constructor.
 
 The optional `options` object may contain:
 

--- a/binding.cc
+++ b/binding.cc
@@ -445,7 +445,6 @@ struct BaseWorker {
     } else if (status_.IsCorruption()) {
       argv = CreateCodeError(env, "LEVEL_CORRUPTION", errMsg_);
     } else if (status_.IsIOError()) {
-      // TODO: add codes to abstract-level readme
       if (strlen(errMsg_) > 15 && strncmp("IO error: lock ", errMsg_, 15) == 0) { // env_posix.cc
         argv = CreateCodeError(env, "LEVEL_LOCKED", errMsg_);
       } else if (strlen(errMsg_) > 19 && strncmp("IO error: LockFile ", errMsg_, 19) == 0) { // env_win.cc

--- a/binding.cc
+++ b/binding.cc
@@ -444,6 +444,15 @@ struct BaseWorker {
       argv = CreateCodeError(env, "LEVEL_NOT_FOUND", errMsg_);
     } else if (status_.IsCorruption()) {
       argv = CreateCodeError(env, "LEVEL_CORRUPTION", errMsg_);
+    } else if (status_.IsIOError()) {
+      // TODO: add codes to abstract-level readme
+      if (strlen(errMsg_) > 15 && strncmp("IO error: lock ", errMsg_, 15) == 0) { // env_posix.cc
+        argv = CreateCodeError(env, "LEVEL_LOCKED", errMsg_);
+      } else if (strlen(errMsg_) > 19 && strncmp("IO error: LockFile ", errMsg_, 19) == 0) { // env_win.cc
+        argv = CreateCodeError(env, "LEVEL_LOCKED", errMsg_);
+      } else {
+        argv = CreateCodeError(env, "LEVEL_IO_ERROR", errMsg_);
+      }
     } else {
       argv = CreateError(env, errMsg_);
     }

--- a/test/lock-test.js
+++ b/test/lock-test.js
@@ -1,0 +1,52 @@
+'use strict'
+
+const test = require('tape')
+const tempy = require('tempy')
+const fork = require('child_process').fork
+const path = require('path')
+const { ClassicLevel } = require('..')
+
+test('lock held by same process', async function (t) {
+  t.plan(2)
+
+  const location = tempy.directory()
+  const db1 = new ClassicLevel(location)
+  await db1.open()
+  const db2 = new ClassicLevel(location)
+
+  try {
+    await db2.open()
+  } catch (err) {
+    t.is(err.code, 'LEVEL_DATABASE_NOT_OPEN', 'second instance failed to open')
+    t.is(err.cause.code, 'LEVEL_LOCKED', 'second instance got lock error')
+  }
+
+  return db1.close()
+})
+
+test('lock held by other process', function (t) {
+  t.plan(6)
+
+  const location = tempy.directory()
+  const db = new ClassicLevel(location)
+
+  db.open(function (err) {
+    t.ifError(err, 'no open error')
+
+    const child = fork(path.join(__dirname, 'lock.js'), [location])
+
+    child.on('message', function (err) {
+      t.is(err.code, 'LEVEL_DATABASE_NOT_OPEN', 'second process failed to open')
+      t.is(err.cause.code, 'LEVEL_LOCKED', 'second process got lock error')
+
+      child.disconnect()
+    })
+
+    child.on('exit', function (code, sig) {
+      t.is(code, 0, 'child exited normally')
+      t.is(sig, null, 'not terminated due to signal')
+
+      db.close(t.ifError.bind(t))
+    })
+  })
+})

--- a/test/lock.js
+++ b/test/lock.js
@@ -1,0 +1,10 @@
+'use strict'
+
+const { ClassicLevel } = require('..')
+
+const location = process.argv[2]
+const db = new ClassicLevel(location)
+
+db.open(function (err) {
+  process.send(err)
+})


### PR DESCRIPTION
This allows `rave-level` (the `abstract-level` replacement of `level-party`) to catch this specific error, instead of using a [catch-all](https://github.com/Level/party/blob/6d5dc4f0740c6f4fd439ec696cc9bf667fb2b643/index.js#L44-L54) that swallows other errors.