### PR TITLE
Refactor: handle view encoding (Uint8Array) natively

### DIFF
--- a/binding.cc
+++ b/binding.cc
@@ -344,10 +344,7 @@ struct Entry {
   static void Convert (napi_env env, const std::string* s, const Encoding encoding, napi_value& result) {
     if (s == NULL) {
       napi_get_undefined(env, &result);
-    } else if (encoding == Encoding::buffer) {
-      napi_create_buffer_copy(env, s->size(), s->data(), NULL, &result);
-    } else if (encoding == Encoding::view) {
-      // TODO: use napi_create_typedarray if performance is equal or better
+    } else if (encoding == Encoding::buffer || encoding == Encoding::view) {
       napi_create_buffer_copy(env, s->size(), s->data(), NULL, &result);
     } else {
       napi_create_string_utf8(env, s->data(), s->size(), &result);

--- a/index.d.ts
+++ b/index.d.ts
@@ -28,7 +28,7 @@ import {
  * @template VDefault The default type of values if not overridden on operations.
  */
 declare class ClassicLevel<KDefault = string, VDefault = string>
-  extends AbstractLevel<string | Buffer, KDefault, VDefault> {
+  extends AbstractLevel<string | Buffer | Uint8Array, KDefault, VDefault> {
   /**
    * Database constructor.
    *

--- a/index.js
+++ b/index.js
@@ -28,7 +28,8 @@ class ClassicLevel extends AbstractLevel {
     super({
       encodings: {
         buffer: true,
-        utf8: true
+        utf8: true,
+        view: true
       },
       seek: true,
       createIfMissing: true,


### PR DESCRIPTION
Replaces the internal asBuffer option with an encoding option that can be one of buffer, utf8 or view, and converts data accordingly. No longer need to transcode view to buffer.

Has no performance effect on `get()` with utf8, buffer or view encoding:

<details>
<summary>Click to expand</summary>

![get 1655539636853](https://user-images.githubusercontent.com/3055345/174428966-4735b3e1-3d17-4861-9402-e86e066359c3.png)
![get 1655540192223](https://user-images.githubusercontent.com/3055345/174429280-a0d4d3cb-99aa-4af0-ad23-3948dc147d38.png)
![get 1655540226332](https://user-images.githubusercontent.com/3055345/174429283-427ebd8d-90ce-436b-94e5-85a447987934.png)

</details>

Same for `iterator()` (main is slightly faster at utf8 in this graph, but on average there's no difference):

<details>
<summary>Click to expand</summary>

![iterate 1655540600711](https://user-images.githubusercontent.com/3055345/174429538-8148d7db-07a1-4444-961b-ecf4768937a5.png)

</details>