### PR TITLE
Remove completed TODO comment

### DIFF
--- a/binding.cc
+++ b/binding.cc
@@ -777,12 +777,6 @@ struct BaseIterator {
   }
 
   bool OutOfRange (const leveldb::Slice& target) const {
-    // TODO: benchmark to see if this is worth it
-    // if (upperBoundOnly && !reverse_) {
-    //   return ((lt_  != NULL && target.compare(*lt_) >= 0) ||
-    //           (lte_ != NULL && target.compare(*lte_) > 0));
-    // }
-
     // The lte and gte options take precedence over lt and gt respectively
     if (lte_ != NULL) {
       if (target.compare(*lte_) > 0) return true;


### PR DESCRIPTION
An iterator with a `gt` or `gte` option first seeks to the key greater than or equal to that option. It's not necessary to then compare every subsequent key to `gt` or `gte`.

Same goes for reverse iterators with `lt` or `lte`.

Makes no difference in benchmarks. Specific cases may benefit a little, like when keys are heavily padded (e.g. having to compare 0000001 against 0000002) which I tried and failed to simulate.