### PR TITLE
test: fix race condition

### DIFF
--- a/test/multithreading-test.js
+++ b/test/multithreading-test.js
@@ -27,7 +27,7 @@ test('check multithreading flag works as expected', async function (t) {
   const db1 = new ClassicLevel(location)
   await db1.open()
   t.is(db1.location, location)
-  
+
   // check that must set multithreading flag on all instances
   let db2
   try {

--- a/test/multithreading-test.js
+++ b/test/multithreading-test.js
@@ -25,12 +25,13 @@ test('check multithreading flag works as expected', async function (t) {
   t.plan(9)
   const location = tempy.directory()
   const db1 = new ClassicLevel(location)
-  const db2 = new ClassicLevel(location)
-
-  // check that must set multithreading flag on all instances
   await db1.open()
   t.is(db1.location, location)
+  
+  // check that must set multithreading flag on all instances
+  let db2
   try {
+    db2 = new ClassicLevel(location)
     await db2.open({ multithreading: true })
   } catch (err) {
     t.is(err.code, 'LEVEL_DATABASE_NOT_OPEN', 'second instance failed to open')


### PR DESCRIPTION
In one unit test there were two sync constructors next to each other that were each calling async open through a nextTick in abstract-level [here](https://github.com/Level/abstract-level/blob/18409b79a1495e545b90ab2ed34f79595d3e7512/abstract-level.js#L100). The next line of the unit test called that same function to check that it errored.

The initialization is managed through events and the race was in the open resolution and event reporting between the several calls to "open" which sometimes was caught as as explicit call in a try/catch and sometimes not as a nextTick call from the constructor.

Moving the constructor into the try/catch and awaiting the second call of `open` ensures that the race is caught correctly in the unit test.

The only way to "fix"/remove the race would be to breaking-change the way constructor `deferOpen`s the db by defaulting to false. That will break the behavior for all consumers that rely on that behavior.

It seems unlikely for anyone to put two constructors next to each other so I recommend not changing the behavior and I simply updated the unit test to check for how the library would most likely be used in practice.