### PR TITLE
Implement explicit snapshots

### DIFF
--- a/iterator.js
+++ b/iterator.js
@@ -21,11 +21,11 @@ const STATE_ENDED = 1
 // so it'll typically just make one nextv(1000) call and there's
 // no performance gain in overriding _all().
 class Iterator extends AbstractIterator {
-  constructor (db, context, options) {
+  constructor (db, context, options, snapshotCtx) {
     super(db, options)
 
     this[kState] = new Uint8Array(1)
-    this[kContext] = binding.iterator_init(context, this[kState], options)
+    this[kContext] = binding.iterator_init(context, this[kState], options, snapshotCtx)
     this[kFirst] = true
     this[kCache] = empty
     this[kPosition] = 0
@@ -104,7 +104,8 @@ class Iterator extends AbstractIterator {
       this[kSignal] = null
     }
 
-    return binding.iterator_close(this[kContext])
+    // This is synchronous because that's faster than creating async work
+    binding.iterator_close(this[kContext])
   }
 
   [kAbort] () {


### PR DESCRIPTION
See https://github.com/Level/community/issues/118. TLDR:

```js
await db.put('example', 'before')
const snapshot = db.snapshot()
await db.put('example', 'after')
await db.get('example', { snapshot })) // Returns 'before'
await snapshot.close()
```

This was relatively easy to implement because it's merely exposing an existing LevelDB feature. Which we were already using too (for example, creating an iterator internally creates a snapshot; I now refer to that as an "implicit" snapshot). The only challenge was garbage collection and state management. For that I knew I could copy iterator logic but I wanted to avoid its technical debt, so I first cleaned that up:

- [`binding.iterator_close()`](https://github.com/Level/classic-level/blob/c2a6c3ddd6f3c82d54ec9c7cb47de57c32b68256/binding.cc#L1875-L1887) is now synchronous, because that's 2x faster than `napi_create_async_work`, let alone executing that async work. Measured with `performance.timerify(binding.iterator_close)`. Simplifies state.
- I changed the database reference ([`Database#ref_`](https://github.com/Level/classic-level/blob/c2a6c3ddd6f3c82d54ec9c7cb47de57c32b68256/binding.cc#L1119)) from a weak to a strong reference, preventing GC until `db.close()`. I thought this would remove the need for strong references to iterators & snapshots seeing as the `AbstractLevel` class already has references in the [`db[kResources]`](https://github.com/Level/abstract-level/blob/f81d3483f1d494f8c8f6695f50a314fc636d4543/abstract-level.js#L46) set, but a new unit test in [`iterator-gc-test.js`](https://github.com/Level/classic-level/blob/c2a6c3ddd6f3c82d54ec9c7cb47de57c32b68256/test/iterator-gc-test.js#L52-L74) proved me wrong. So I kept that as-is (would like to revisit).
- Having a strong reference to the database removed the need for the [`IncrementPriorityWork`](https://github.com/Level/classic-level/blob/c2a6c3ddd6f3c82d54ec9c7cb47de57c32b68256/binding.cc#L623) function to increment the refcount of said reference. It now just increments a `std::atomic<int>` (for our own state outside of V8).
- Iterators no longer call `IncrementPriorityWork` which had 2 purposes:
  1. Increase the db reference count. See above.
  2. Delay database close until iterators were closed. A leftover from before `abstract-level` which [closes](https://github.com/Level/abstract-level/blob/f81d3483f1d494f8c8f6695f50a314fc636d4543/abstract-level.js#L268) iterators & snapshots before calling `db._close()`.

I then moved common logic for references and teardown to a new struct called [`Resource`](https://github.com/Level/classic-level/blob/c2a6c3ddd6f3c82d54ec9c7cb47de57c32b68256/binding.cc#L708-L744), inherited by `Iterator` and [`ExplicitSnapshot`](https://github.com/Level/classic-level/blob/c2a6c3ddd6f3c82d54ec9c7cb47de57c32b68256/binding.cc#L746-L760). The latter is a new struct that wraps a LevelDB snapshot.

Keeping snapshots open during read operations like `db.get()` is handled in `abstract-level` through [`AbstractSnapshot#ref()`](https://github.com/Level/abstract-level/blob/f81d3483f1d494f8c8f6695f50a314fc636d4543/abstract-snapshot.js#L30-L44).

I think further cleanup is possible (and to move more state management to JS) but I'll save that for a future PR.

This PR depends on https://github.com/Level/abstract-level/pull/93 but is otherwise complete.