### PR TITLE
Add return type `undefined` to the `get` methods

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -48,8 +48,8 @@ declare class ClassicLevel<KDefault = string, VDefault = string>
   open (): Promise<void>
   open (options: OpenOptions): Promise<void>
 
-  get (key: KDefault): Promise<VDefault>
-  get<K = KDefault, V = VDefault> (key: K, options: GetOptions<K, V>): Promise<V>
+  get (key: KDefault): Promise<VDefault | undefined>
+  get<K = KDefault, V = VDefault> (key: K, options: GetOptions<K, V>): Promise<V|undefined>
 
   getMany (keys: KDefault[]): Promise<VDefault[]>
   getMany<K = KDefault, V = VDefault> (keys: K[], options: GetManyOptions<K, V>): Promise<V[]>

--- a/index.d.ts
+++ b/index.d.ts
@@ -49,10 +49,10 @@ declare class ClassicLevel<KDefault = string, VDefault = string>
   open (options: OpenOptions): Promise<void>
 
   get (key: KDefault): Promise<VDefault | undefined>
-  get<K = KDefault, V = VDefault> (key: K, options: GetOptions<K, V>): Promise<V|undefined>
+  get<K = KDefault, V = VDefault> (key: K, options: GetOptions<K, V>): Promise<V | undefined>
 
-  getMany (keys: KDefault[]): Promise<VDefault[]>
-  getMany<K = KDefault, V = VDefault> (keys: K[], options: GetManyOptions<K, V>): Promise<V[]>
+  getMany (keys: KDefault[]): Promise<(VDefault | undefined)[]>
+  getMany<K = KDefault, V = VDefault> (keys: K[], options: GetManyOptions<K, V>): Promise<(V | undefined)[]>
 
   put (key: KDefault, value: VDefault): Promise<void>
   put<K = KDefault, V = VDefault> (key: K, value: V, options: PutOptions<K, V>): Promise<void>


### PR DESCRIPTION
Add `undefined` as potential return type for the `get` and `getMany` methods.

Fixes #116 